### PR TITLE
add php wrapper bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 !docker-compose.yml
 !/Logs/
 !/Dockerfiles/
+!php7wrapper

--- a/php7wrapper
+++ b/php7wrapper
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run --rm -i \
+    -v $PWD:/var/www \
+    cscolabear/7.2-fpm php "$@"


### PR DESCRIPTION
有時候本機需要呼叫 php (e.g. vscode)
但本機的 php 版本不盡理想，或是根本沒裝

增加一個 bash 快速呼叫、執行 docker php

```
chmod  755 php7wrapper
```

要不要 ln 取代或新增至 /usr/bin 再看個人喜好


ref.
https://github.com/felixfbecker/vscode-php-intellisense/issues/150
